### PR TITLE
Support base_image to specify base image to use.

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -27,6 +27,7 @@ resource "ko_image" "example" {
 
 ### Optional
 
+- `base_image` (String) base image to use
 - `platforms` (String) platforms to build
 
 ### Read-Only


### PR DESCRIPTION
This enables chained ko builds, where a previous ko_image resource can
be fed into a subsequent ko_image's base_image. If you're into that kind
of thing.

cc @mattmoor